### PR TITLE
added some common container definitions 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+_build
+validation-files/*
+output/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+# Install some basic pre-requisites
+RUN apt-get -qq update \
+  && apt-get install -q -y \
+    sudo wget git \
+    build-essential g++ gcc m4 make pkg-config libgmp3-dev unzip cmake \
+    opam \
+    python3 python3-pip \
+    time \
+    z3 \
+    libz3-dev \
+  && apt-get clean -q -y \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install solc-select
+RUN solc-select install 0.7.6 \
+  && solc-select use 0.7.6 \
+  && solc-select install 0.4.26
+ENV PATH=$PATH:/root/.solc-select/artifacts/
+
+WORKDIR /build
+ADD . ./verismart
+
+WORKDIR /build/verismart
+RUN opam init -y --disable-sandboxing \
+  && eval $(opam env) \
+  && opam update \
+  && opam install -y \
+    conf-m4.1 ocamlfind ocamlbuild num yojson batteries ocamlgraph zarith z3
+# Make sure that ocamlbuild and such exists in the path
+RUN echo 'eval $(opam env)' >> $HOME/.bashrc
+
+RUN chmod +x build && eval $(opam env) && ./build && ./main.native --help >/dev/null
+RUN ln -s $(realpath ./main.native) /usr/local/bin/verismart

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+TARGET=main.native
+INCLUDE_DIRS=src/frontend,src/pre,src/pre/interval,src/verify,src/vlang,src/util,src/checker,src/exploit
+
+build:
+	time ocamlbuild src/$(TARGET) -use-ocamlfind -tag thread -Is $(INCLUDE_DIRS)
+
+clean:
+	ocamlbuild -clean
+
+rebuild: clean build
+
+.PHONY: clean build rebuild debug

--- a/_tags
+++ b/_tags
@@ -1,1 +1,1 @@
-true: package(batteries), package(str), package(Z3), package(yojson), package(ocamlgraph)
+true: package(batteries), package(str), package(z3), package(yojson), package(ocamlgraph)

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TARGET=main.native
 INCLUDE_DIRS=src/frontend,src/pre,src/pre/interval,src/verify,src/vlang,src/util,src/checker,src/exploit

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.ocaml
+    pkgs.opam
+
+    pkgs.ocamlPackages.findlib
+    pkgs.ocamlPackages.ocamlbuild
+    pkgs.ocamlPackages.batteries
+    pkgs.ocamlPackages.ocamlgraph
+    pkgs.ocamlPackages.num
+    pkgs.ocamlPackages.yojson
+    pkgs.ocamlPackages.zarith
+    pkgs.ocamlPackages.z3
+
+    pkgs.z3
+
+    pkgs.gnum4
+    pkgs.gnumake
+
+    # pkgs.solc-select
+    pkgs.solc
+  ];
+}


### PR DESCRIPTION
It is always nice to ship with an easy way to install and setup projects. Since I had to do it anyway for myself, I thought I'd share:

I added
* a `Dockerfile` based on Ubuntu for easy deployment e.g. to some server
* a `shell.nix` for a quick development setup with nix
* a `Makefile`, which is imho more standard than `./build`

Note that I switched to using a pre-built z3 (I think the version is currently 4.8.14 or something) to keep build times reasonable. I am not sure whether this has any implications. 

I tested with the leaking ether example solidity file and everything seems to be working correctly.